### PR TITLE
fix: GoatCounter trailing-slash path mismatch

### DIFF
--- a/src/components/GoatCounter.astro
+++ b/src/components/GoatCounter.astro
@@ -41,8 +41,11 @@ const base = code.length > 0 ? `https://${code}.goatcounter.com` : null;
 			el.dataset.gcLoaded = "1";
 			const base = el.dataset.gcBase!;
 			// GoatCounter appends the page path (with its leading slash) after /counter,
-			// e.g. /counter//posts/foo/.json. "TOTAL" is the whole-site figure.
-			const path = el.dataset.gcPath || location.pathname;
+			// e.g. /counter//posts/foo.json. "TOTAL" is the whole-site figure.
+			let path = el.dataset.gcPath || location.pathname;
+			// GoatCounter normalizes stored paths by stripping the trailing slash (except
+			// root "/"), so /posts/foo/ is keyed as /posts/foo — match that or we 404.
+			if (path !== "TOTAL" && path.length > 1) path = path.replace(/\/+$/, "");
 			const metric = el.dataset.gcMetric === "count_unique" ? "count_unique" : "count";
 			const valueEl = el.querySelector<HTMLElement>(".gc-count-value");
 			try {


### PR DESCRIPTION
## Problem

Per-post view counts never rendered. GoatCounter normalizes stored paths by stripping the trailing slash (the dashboard shows `/posts/ironman-2021`), but the on-page counter queried `location.pathname` = `/posts/ironman-2021/`, so the `/counter/` endpoint always 404'd → counter stayed hidden.

## Fix

Strip the trailing slash from the path before building the counter URL (root `/` kept as-is). One-line change in `GoatCounter.astro`.

## Note

GoatCounter's public `/counter/` endpoint also updates on a periodic cycle (not real-time), so freshly recorded paths take a while to appear there even though the dashboard shows them immediately. That's a service-side delay, not a code issue.