### PR TITLE
fix: hide GoatCounter counter until count is positive

### DIFF
--- a/src/components/GoatCounter.astro
+++ b/src/components/GoatCounter.astro
@@ -52,8 +52,15 @@ const base = code.length > 0 ? `https://${code}.goatcounter.com` : null;
 				const res = await fetch(`${base}/counter/${encodeURI(path)}.json`);
 				if (!res.ok) throw new Error(String(res.status));
 				const data = (await res.json()) as Record<string, string>;
-				if (valueEl) valueEl.textContent = data[metric] ?? "0";
-				el.hidden = false;
+				const raw = data[metric] ?? "0";
+				// GoatCounter's TOTAL/aggregate counters can lag (cached, ~hourly), so a
+				// real page may briefly report 0. Stay hidden until there's a positive
+				// number rather than show a misleading "0 visitors".
+				const n = Number.parseInt(raw.replace(/[^0-9]/g, ""), 10) || 0;
+				if (n > 0) {
+					if (valueEl) valueEl.textContent = raw;
+					el.hidden = false;
+				}
 			} catch {
 				// No data yet, or visitor counts disabled in GoatCounter — stay hidden.
 			}


### PR DESCRIPTION
## Problem

The footer showed **"0 visitors"** — not a bug in tracking, but GoatCounter's `TOTAL` counter endpoint is cached/aggregated (~hourly), so it reports `0` for a while even when the dashboard already has visits. Rendering that 0 looks broken.

## Fix

Only reveal a counter once it reports a positive number (parse out the thousands separators first). During the propagation lag the counter stays hidden instead of showing `0`, and genuinely-zero pages no longer show "0 views" either.